### PR TITLE
Removed config_common.h include from config.h

### DIFF
--- a/totem/config.h
+++ b/totem/config.h
@@ -17,8 +17,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
-#include "config_common.h"
-
 /* USB Device descriptor parameter */
 /*#define VENDOR_ID       0x3A3C
 #define PRODUCT_ID      0x0002


### PR DESCRIPTION
Get the following message in a loop when trying to build
```
quantum/config_common.h:19:9: note: #pragma message: 'config_common.h' should no longer be included!
 #pragma message("'config_common.h' should no longer be included!")
```

Removing the include allows the build to finish and everything is working fine.

Not sure if this is only valid for the latest versions of QMK, I use QMK as a submodule pointing to latest on master.